### PR TITLE
Feat/image read transform api

### DIFF
--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -89,13 +89,11 @@ class ImageDatasource(FileBasedDatasource):
             image = image.resize((width, height), resample=Image.BILINEAR)
         if self.mode is not None:
             image = image.convert(self.mode)
-
         if self.transform is not None:
-            array = self.transform(image)
-            # @ronyw: Casting to `np.array` type here so we don't need to do it in the `collate_fn`
-            array = np.array(array)
-        else:
-            array = np.array(image)
+            image = self.transform(image)
+
+        # @ronyw: Casting to `np.array` type here so we don't need to do it in the `collate_fn`
+        array = np.array(image)
         item = {"image": array}
         yield item
 

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -43,7 +43,6 @@ class ImageDatasource(FileBasedDatasource):
         transform: Optional[Callable] = None,  # @ron
         **file_based_datasource_kwargs,
     ):
-        # print(self._NUM_THREADS_PER_TASK)
         super().__init__(paths, **file_based_datasource_kwargs)
 
         _check_import(self, module="PIL", package="Pillow")

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -789,6 +789,7 @@ def read_images(
     file_extensions: Optional[List[str]] = ImageDatasource._FILE_EXTENSIONS,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
+    transform: Optional[Callable] = None,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from image files.
 
@@ -912,6 +913,7 @@ def read_images(
         ignore_missing_paths=ignore_missing_paths,
         shuffle=shuffle,
         file_extensions=file_extensions,
+        transform=transform
     )
     return read_datasource(
         datasource,


### PR DESCRIPTION
## Why are these changes needed?

In `image_loader_microbenchmark.py`, there are currently two ways to transform images, each with significant limitations:
- Using `map` to transform images on a per-image basis. This is slow because we are not vectorizing our operations.
- Using `map_batches` to transform a batch of images at once. However, this necessitates the use of image resizing in the `read_images` api, before `map_batches`. Otherwise, the outputs are ragged arrays and we can't apply vectorization either.

The temporary solution here is to add a `transform=Optional[Callable]` parameter to the `read_images` api. Any desired transformations on the images can be applied as the images are read. For example, as in the pipeline, we can use `torchvision.transforms.Compose` to chain several PIL transformations together. 
```
def get_transform(to_torch_tensor):
    transform = torchvision.transforms.Compose(
        [
            ...
        ]
        + ([torchvision.transforms.ToTensor()] if to_torch_tensor else [])
    )
    return transform

ray_dataset = ray.data.read_images(
            args.data_root,
            mode="RGB",
            transform=get_transform(False),
)
```

Finally, to ensure the outputs are `torch.Tensor`s, we can pass in a custom `collate_fn` to `iter_torch_batches`:
```
def _collate_fn_arr_pil_images_to_tensor(batch: np.ndarray) -> torch.Tensor:
    batch = batch["image"]
    
    arrays = np.transpose(batch, axes=(0, 3, 1, 2))
    tensor_batch = torch.from_numpy(arrays)
    
    batch = {"image": tensor_batch}
    return batch
```

## Tput (with `pillow-simd`)
```
tf_data+transform,1684.9446185740537
torch+transform,1716.6095219218264
ray_data+map_transform,1802.2751834315588

tf_data+transform,1627.2530314975315
torch+transform,1577.324291053851
ray_data+map_transform,1616.0546900449306

tf_data+transform,1698.4883610939994
torch+transform,1709.1816354366601
ray_data+map_transform,1823.7616817532612
```