### PR TITLE
Scheduling policy fixes for multi-stage hetero-resources pipelines

### DIFF
--- a/python/ray/data/_internal/execution/memory_budget.py
+++ b/python/ray/data/_internal/execution/memory_budget.py
@@ -1,0 +1,145 @@
+import logging
+import time
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ray.data._internal.execution.resource_manager import ResourceManager
+
+logger = logging.getLogger(__name__)
+
+
+def humanize(num, suffix="B"):
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f}Yi{suffix}"
+
+
+# @lsf
+class GlobalMemoryBudget:
+    def __init__(self, initial_budget: float):
+        self._budget = initial_budget
+        self._last_replenish_time = -1
+        logger.debug("@lsf Initial global memory budget is", humanize(self._budget))
+
+    def get(self) -> float:
+        return self._budget
+
+    def can_spend(self, amount: float) -> bool:
+        return self._budget >= amount
+
+    def spend(self, amount: float):
+        if not self.can_spend(amount):
+            raise ValueError("Insufficient global memory budget")
+        self._budget -= amount
+        return self._budget
+
+    def spend_if_available(self, amount: float) -> bool:
+        if self.can_spend(amount):
+            self.spend(amount)
+            return True
+        return False
+
+    def replenish(self):
+        self._budget = self._budget
+        logger.debug("@lsf Replenished memory budget to", humanize(self._budget))
+
+
+# @mzm
+class PerOpMemoryBudget:
+    def __init__(self):
+        self._budget = -1
+        self._last_replenish_time = -1
+
+    def get(self) -> float:
+        return self._budget
+
+    def can_spend(self, amount: float) -> bool:
+        return self._budget >= amount
+
+    def spend(self, amount: float):
+        if not self.can_spend(amount):
+            raise ValueError("Insufficient memory budget")
+        self._budget -= amount
+        return self._budget
+
+    def spend_if_available(self, amount: float) -> bool:
+        if self.can_spend(amount):
+            self.spend(amount)
+            return True
+        return False
+
+    def replenish(self, op, resource_manager: "ResourceManager") -> float:
+        # Initialize output_budget to object_store_memory.
+        INITIAL_BUDGET = resource_manager.get_global_limits().object_store_memory
+        if self._budget == -1:
+            self._budget = INITIAL_BUDGET
+            self._last_replenish_time = time.time()
+            return
+
+        grow_rate = self._get_grow_rate(op, resource_manager)
+        now = time.time()
+        time_elapsed = now - self._last_replenish_time
+
+        self._budget += time_elapsed * grow_rate
+        # Cap output_budget to object_store_memory
+        self._budget = min(INITIAL_BUDGET, self._budget)
+        logger.debug(
+            f"@mzm INITIAL_BUDGET: {humanize(INITIAL_BUDGET)}, "
+            f"self.output_budget: {self._budget}, "
+            f"time elapsed: {time_elapsed} "
+            f"grow_rate: {grow_rate}"
+        )
+        self._last_replenish_time = now
+
+    def _get_grow_rate(self, op, resource_manager: "ResourceManager") -> float:
+        time_for_pipeline_to_process_one_data = 0
+        next_op = op
+        output_input_multipler = 1
+        time_for_op = 0
+
+        while len(next_op.output_dependencies) > 0:
+            assert len(next_op.output_dependencies) == 1
+
+            next_op = next_op.output_dependencies[0]
+
+            # Initialize grow rate to be 0.
+            if (
+                not next_op._metrics.average_task_duration
+                or not next_op._metrics.average_bytes_inputs_per_task
+                or not next_op._metrics.average_bytes_outputs_per_task
+            ):
+                continue
+
+            time_for_op += (
+                output_input_multipler
+                * next_op._metrics.average_task_duration
+                / next_op._metrics.average_bytes_inputs_per_task
+            )
+
+            output_input_multipler *= (
+                next_op._metrics.average_bytes_outputs_per_task
+                / next_op._metrics.average_bytes_inputs_per_task
+            )
+
+            if next_op.incremental_resource_usage().cpu == 0:
+                # @MaoZiming: if it is on GPU.
+                # However, time_for_op still accumulates.
+                # If the last stage is on GPU, then you don't have to care.
+                continue
+            time_for_pipeline_to_process_one_data += time_for_op
+            time_for_op = 0
+
+        num_executors_not_running_op = (
+            resource_manager.get_global_limits().cpu
+            - op.num_active_tasks() * op.incremental_resource_usage().cpu
+        )
+
+        if time_for_pipeline_to_process_one_data == 0:
+            return 0
+
+        return (
+            1 / time_for_pipeline_to_process_one_data
+        ) * num_executors_not_running_op

--- a/python/ray/data/_internal/execution/memory_budget.py
+++ b/python/ray/data/_internal/execution/memory_budget.py
@@ -1,7 +1,9 @@
 import logging
 import time
-
 from typing import TYPE_CHECKING
+
+import ray
+from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.resource_manager import ResourceManager
@@ -12,7 +14,7 @@ logger = logging.getLogger(__name__)
 def humanize(num, suffix="B"):
     for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
         if abs(num) < 1024.0:
-            return f"{num:3.1f}{unit}{suffix}"
+            return f"{num:3.2f}{unit}{suffix}"
         num /= 1024.0
     return f"{num:.1f}Yi{suffix}"
 
@@ -20,9 +22,10 @@ def humanize(num, suffix="B"):
 # @lsf
 class GlobalMemoryBudget:
     def __init__(self, initial_budget: float):
+        self._initial_budget = initial_budget
         self._budget = initial_budget
         self._last_replenish_time = -1
-        logger.debug("@lsf Initial global memory budget is", humanize(self._budget))
+        logger.debug(f"@lsf Initial global memory budget is {humanize(self._budget)}")
 
     def get(self) -> float:
         return self._budget
@@ -42,9 +45,76 @@ class GlobalMemoryBudget:
             return True
         return False
 
-    def replenish(self):
-        self._budget = self._budget
-        logger.debug("@lsf Replenished memory budget to", humanize(self._budget))
+    def global_replenish(self, resource_manager: "ResourceManager", topology):
+        grow_rate = _get_global_growth_rate(resource_manager, topology)
+        now = time.time()
+        time_elapsed = now - self._last_replenish_time
+
+        self._budget += time_elapsed * grow_rate
+        # Cap output_budget to object_store_memory
+        self._budget = min(self._initial_budget, self._budget)
+        logger.debug(
+            f"@lsf INITIAL_BUDGET: {humanize(self._initial_budget)}, "
+            f"self.output_budget: {humanize(self._budget)}, "
+            f"time elapsed: {time_elapsed:.2f}s, "
+            f"replenish rate: {humanize(grow_rate)}/s"
+        )
+        self._last_replenish_time = now
+
+
+def tasks_recently_completed(metrics, duration) -> tuple[int, float]:
+    """Return the number of tasks that started running recently, and the time span
+    between the first task started running and now."""
+    now = time.time()
+    time_start = now - duration
+    first_task_start = now
+
+    num_tasks = 0
+    for t in metrics._running_tasks_start_time.values():
+        if t >= time_start:
+            num_tasks += 1
+            first_task_start = min(first_task_start, t)
+
+    return num_tasks, now - first_task_start
+
+
+def is_first_op(op) -> bool:
+    return len(op.input_dependencies) == 1 and isinstance(
+        op.input_dependencies[0], InputDataBuffer
+    )
+
+
+def _get_global_growth_rate(resource_manager: "ResourceManager", topology):
+    DURATION = 30  # consider tasks in the last 30 seconds
+
+    ret = 0
+    for op, _state in topology.items():
+        task_input_size = op._metrics.average_bytes_inputs_per_task
+        if task_input_size is None:
+            if is_first_op(op):
+                task_input_size = 0
+            else:
+                task_input_size = (
+                    ray.data.DataContext.get_current().target_max_block_size
+                )
+
+        num_completed, timespan = tasks_recently_completed(op._metrics, DURATION)
+        if num_completed > 0:
+            task_completion_rate = num_completed / timespan
+        else:
+            task_duration = op._metrics.average_task_duration
+            num_slots = resource_manager.get_global_limits().cpu
+            if task_duration is not None:
+                task_completion_rate = num_slots / task_duration
+            else:
+                task_completion_rate = 0
+
+        logger.debug(
+            f"@lsf Replenishing {op.name} input size {humanize(task_input_size)} completion rate {task_completion_rate:.2f}"
+        )
+        ret += task_input_size * task_completion_rate
+
+    return ret
 
 
 # @mzm
@@ -71,7 +141,7 @@ class PerOpMemoryBudget:
             return True
         return False
 
-    def replenish(self, op, resource_manager: "ResourceManager") -> float:
+    def replenish(self, op, resource_manager: "ResourceManager"):
         # Initialize output_budget to object_store_memory.
         INITIAL_BUDGET = resource_manager.get_global_limits().object_store_memory
         if self._budget == -1:
@@ -79,7 +149,7 @@ class PerOpMemoryBudget:
             self._last_replenish_time = time.time()
             return
 
-        grow_rate = self._get_grow_rate(op, resource_manager)
+        grow_rate = _get_per_op_grow_rate(op, resource_manager)
         now = time.time()
         time_elapsed = now - self._last_replenish_time
 
@@ -88,58 +158,57 @@ class PerOpMemoryBudget:
         self._budget = min(INITIAL_BUDGET, self._budget)
         logger.debug(
             f"@mzm INITIAL_BUDGET: {humanize(INITIAL_BUDGET)}, "
-            f"self.output_budget: {self._budget}, "
-            f"time elapsed: {time_elapsed} "
-            f"grow_rate: {grow_rate}"
+            f"self.output_budget: {humanize(self._budget)}, "
+            f"time elapsed: {time_elapsed:.2f}s, "
+            f"grow_rate: {humanize(grow_rate)}/s"
         )
         self._last_replenish_time = now
 
-    def _get_grow_rate(self, op, resource_manager: "ResourceManager") -> float:
-        time_for_pipeline_to_process_one_data = 0
-        next_op = op
-        output_input_multipler = 1
-        time_for_op = 0
 
-        while len(next_op.output_dependencies) > 0:
-            assert len(next_op.output_dependencies) == 1
+def _get_per_op_grow_rate(op, resource_manager: "ResourceManager") -> float:
+    time_for_pipeline_to_process_one_data = 0
+    next_op = op
+    output_input_multipler = 1
+    time_for_op = 0
 
-            next_op = next_op.output_dependencies[0]
+    while len(next_op.output_dependencies) > 0:
+        assert len(next_op.output_dependencies) == 1
 
-            # Initialize grow rate to be 0.
-            if (
-                not next_op._metrics.average_task_duration
-                or not next_op._metrics.average_bytes_inputs_per_task
-                or not next_op._metrics.average_bytes_outputs_per_task
-            ):
-                continue
+        next_op = next_op.output_dependencies[0]
 
-            time_for_op += (
-                output_input_multipler
-                * next_op._metrics.average_task_duration
-                / next_op._metrics.average_bytes_inputs_per_task
-            )
+        # Initialize grow rate to be 0.
+        if (
+            not next_op._metrics.average_task_duration
+            or not next_op._metrics.average_bytes_inputs_per_task
+            or not next_op._metrics.average_bytes_outputs_per_task
+        ):
+            continue
 
-            output_input_multipler *= (
-                next_op._metrics.average_bytes_outputs_per_task
-                / next_op._metrics.average_bytes_inputs_per_task
-            )
-
-            if next_op.incremental_resource_usage().cpu == 0:
-                # @MaoZiming: if it is on GPU.
-                # However, time_for_op still accumulates.
-                # If the last stage is on GPU, then you don't have to care.
-                continue
-            time_for_pipeline_to_process_one_data += time_for_op
-            time_for_op = 0
-
-        num_executors_not_running_op = (
-            resource_manager.get_global_limits().cpu
-            - op.num_active_tasks() * op.incremental_resource_usage().cpu
+        time_for_op += (
+            output_input_multipler
+            * next_op._metrics.average_task_duration
+            / next_op._metrics.average_bytes_inputs_per_task
         )
 
-        if time_for_pipeline_to_process_one_data == 0:
-            return 0
+        output_input_multipler *= (
+            next_op._metrics.average_bytes_outputs_per_task
+            / next_op._metrics.average_bytes_inputs_per_task
+        )
 
-        return (
-            1 / time_for_pipeline_to_process_one_data
-        ) * num_executors_not_running_op
+        if next_op.incremental_resource_usage().cpu == 0:
+            # @MaoZiming: if it is on GPU.
+            # However, time_for_op still accumulates.
+            # If the last stage is on GPU, then you don't have to care.
+            continue
+        time_for_pipeline_to_process_one_data += time_for_op
+        time_for_op = 0
+
+    num_executors_not_running_op = (
+        resource_manager.get_global_limits().cpu
+        - op.num_active_tasks() * op.incremental_resource_usage().cpu
+    )
+
+    if time_for_pipeline_to_process_one_data == 0:
+        return 0
+
+    return (1 / time_for_pipeline_to_process_one_data) * num_executors_not_running_op

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -11,6 +11,7 @@ from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionResources,
 )
 from ray.data._internal.execution.interfaces.physical_operator import PhysicalOperator
+from ray.data._internal.execution.memory_budget import GlobalMemoryBudget
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.util import memory_string
 from ray.data.context import DataContext
@@ -61,6 +62,10 @@ class ResourceManager:
 
         self._op_resource_allocator: Optional["OpResourceAllocator"] = None
         ctx = DataContext.get_current()
+
+        self.global_memory_budget = GlobalMemoryBudget(
+            self.get_global_limits().object_store_memory
+        )
 
         if ctx.op_resource_reservation_enabled:
             # We'll enable memory reservation if all operators have
@@ -124,9 +129,9 @@ class ResourceManager:
             f = (1.0 + num_ops_so_far) / max(1.0, num_ops_total - 1.0)
             num_ops_so_far += 1
             self._downstream_fraction[op] = min(1.0, f)
-            self._downstream_object_store_memory[
-                op
-            ] = self._global_usage.object_store_memory
+            self._downstream_object_store_memory[op] = (
+                self._global_usage.object_store_memory
+            )
 
             # Update operator's object store usage, which is used by
             # DatasetStats and updated on the Ray Data dashboard.

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -337,12 +337,13 @@ class OpState:
         ):
             return True
 
-        INITIAL_BUDGET = resource_manager.get_global_limits().object_store_memory
+        DEFAULT_OUTPUT_SIZE = resource_manager.get_global_limits().object_store_memory
 
         if not ray.data.DataContext.get_current().is_global_budget_policy:
+            DEFAULT_OUTPUT_SIZE = 1000 * 1024 * 1024
             self.output_budget.replenish(self.op, resource_manager)
             output_size = (
-                self.op._metrics.average_bytes_outputs_per_task or INITIAL_BUDGET
+                self.op._metrics.average_bytes_outputs_per_task or DEFAULT_OUTPUT_SIZE
             )
             logger.debug(
                 f"@mzm {self.op}, "
@@ -353,7 +354,7 @@ class OpState:
 
         output_size = self.op._metrics.average_bytes_outputs_per_task
         if output_size is None:
-            output_size = INITIAL_BUDGET if is_first_op(self.op) else 0
+            output_size = DEFAULT_OUTPUT_SIZE if is_first_op(self.op) else 0
         logger.debug(
             f"@lsf {self.op}, "
             f"global_budget: {humanize(resource_manager.global_memory_budget.get())}, "

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -290,6 +290,7 @@ class DataContext:
     wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
     is_budget_policy: bool = True
     is_conservative_policy: bool = False
+    is_global_budget_policy: bool = False
     retried_io_errors: List[str] = DEFAULT_RETRIED_IO_ERRORS
 
     def __post_init__(self):

--- a/test_large_e2e_backpressure.py
+++ b/test_large_e2e_backpressure.py
@@ -98,5 +98,5 @@ def main(is_flink: bool):
 
 
 if __name__ == "__main__":
-    main(is_flink=True)
+    # main(is_flink=True)
     main(is_flink=False)

--- a/three_stage_problem.py
+++ b/three_stage_problem.py
@@ -5,7 +5,6 @@ import time
 import numpy as np
 import timeline_utils
 import ray
-import psutil
 
 LOG_FILE = "three_stage_problem.log"
 
@@ -42,9 +41,9 @@ def main(is_flink: bool, is_conservative_policy: bool):
     NUM_GPUS = 4
     NUM_ROWS_PER_TASK = 10
     BUFFER_SIZE_LIMIT = 30
-    NUM_TASKS = 16 * 5
+    NUM_TASKS = 80
     NUM_ROWS_TOTAL = NUM_ROWS_PER_TASK * NUM_TASKS
-    BLOCK_SIZE = 10 * 1024 * 1024 * 10
+    BLOCK_SIZE = 100 * 1024 * 1024
 
     def produce(batch):
         logger.log({"name": "producer_start", "id": [int(x) for x in batch["id"]]})
@@ -74,6 +73,7 @@ def main(is_flink: bool, is_conservative_policy: bool):
         data_context.is_budget_policy = False  # Disable our policy.
     else:
         data_context.is_budget_policy = True
+        # data_context.is_global_budget_policy = True
 
     ray.init(
         num_cpus=NUM_CPUS,


### PR DESCRIPTION
In this PR:
* I refactored the memory budget code out into `memory_budget.py`
* The original "budget algorithm" is named `PerOpMemoryBudget`. I changed the treatment of GPU-only stages; seems to work better (see below)
* I tried implementing a new "global memory budget" that tries to regulate all tasks. Doesn't work well.

Everything below is with the modified `budget_policy`; the `global_budget_policy` is not working well yet.

Tested:
* `test_large_e2e_backpressure.py` - good as before, no spilling.
* `three_stage_problem.py` - where the 2nd stage (consumer) returns the entire image (rather than just a number). Before this incurs spilling when using the budget policy; in this new version, no spilling and run time is better than the conservative policy. See screenshot for the new schedule.

![Screenshot 2024-07-29 at 1 12 31 PM](https://github.com/user-attachments/assets/f2d076f5-167f-4938-8261-9239a8e9b536)
